### PR TITLE
Fixes for mysql-related kubectl apply errors

### DIFF
--- a/pipelines/base/manifest/mysql.yaml
+++ b/pipelines/base/manifest/mysql.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        app: mysql
     spec:
       containers:
         - name: mysql
@@ -21,9 +23,10 @@ spec:
             - name: MYSQL_DATABASES
               value: "$(pipelineMysqlDb),$(metadataMysqlDb)"
             - name: MYSQL_ROOT_PASSWORD
-              secretKeyRef:
-                name: mysql-secrets
-                key: root_password
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secrets
+                  key: root_password
             - name: MYSQL_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Fixes
```
error validating data: ValidationError(Deployment.spec.template.spec.containers[0].env[1]): unknown field "secretKeyRef" in io.k8s.api.core.v1.EnvVar
```
and
```
The Deployment "mysql" is invalid: spec.template.metadata.labels: Invalid value: map[string]string(nil): `selector` does not match template `labels`
```