### PR TITLE
Do not allow service port to be mutated - fix #18

### DIFF
--- a/pipelines/base/params.yaml
+++ b/pipelines/base/params.yaml
@@ -27,5 +27,5 @@ varReference:
   kind: StorageClass
 - path: metadata/name
   kind: Service
-- path: spec/ports/port
-  kind: Service
+# - path: spec/ports/port
+#   kind: Service


### PR DESCRIPTION
This PR remove the permission to modify `service/ports/port` to fix #18 

```
when I run the command .
kubectl kustomize overlay/${VARIANT} > kubeflow-pipelines-aws.yaml

I got the config merge issue.

I1027 20:05:10.994651 40204 log.go:172] well-defined vars that were never replaced: mlmdDb,pipelinePath,awsIAMAnnotationKey,dbHost,dbPort,kfp-app-name,kfp-app-version,artifactRepositoryKeyPrefix,groupConcatMaxLen,kfp-namespace,mysqlStorageType,cacheDb,kfp-container-runtime-executor,mysqlPvcName,mysqlStorageSize,pipelineDb,artifactRepositoryBucket,awsIAMRole,awsRegion,kfp-artifact-bucket-name,mysqlStorageClass
Error: 80 is expected to be string
```

@lzuwei  can u double check if we modify service port in our kustomize configs?

Cuz it seems to cuz error, see
- #18 
- https://github.com/kubernetes-sigs/kustomize/issues/1721